### PR TITLE
Check for presence of GenServer before Repo events

### DIFF
--- a/lib/logflare_logger/http_backend.ex
+++ b/lib/logflare_logger/http_backend.ex
@@ -110,7 +110,9 @@ defmodule LogflareLogger.HttpBackend do
 
   @spec flush!(Config.t()) :: {:ok, Config.t()}
   defp flush!(%Config{} = config) do
-    BatchCache.flush(config)
+    if GenServer.whereis(LogflareLogger.Repo) do
+      BatchCache.flush(config)
+    end
 
     schedule_flush(config)
   end


### PR DESCRIPTION
The remote console is crapping out on flush and put commands.

This change will check to see if a GenServer is actually running for the `LogflareLogger.Repo` before it attempts to perform these actions.