### PR TITLE
Fix for anon_function error for  Enum.sort_by/3 within batch_cache.ex

### DIFF
--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -94,7 +94,7 @@ defmodule LogflareLogger.BatchCache do
 
   def sort_by_created_asc(pending_events) do
     # etso id is System.monotonic_time
-    Enum.sort_by(pending_events, & &1.id, :asc)
+    Enum.sort_by(pending_events, &(&1.id), &<=/2)
   end
 
   def events_in_flight() do


### PR DESCRIPTION
This solves the anonymous function error received from batch_cache.ex:44 when you run the backend logger.