### PR TITLE
Fix crash when sys_envs has level as string

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -23,6 +23,8 @@ defmodule LogflareLogger.Utils do
 
     for {"LOGFLARE_" <> k, v} <- envs do
       k = String.downcase(k) |> String.to_atom()
+      v = if k == :level, do: String.to_atom(v), else: v
+
       {k, v}
     end
   end


### PR DESCRIPTION
You can reproduce crash with
```
$ export LOGFLARE_LEVEL=debug
```

Error logs are

```
[error] :gen_event handler LogflareLogger.HttpBackend installed in Logger terminating
** (ArgumentError) argument error
    (kernel 8.4) logger.erl:621: :logger.compare_levels(:info, "debug")
    (logflare_logger_backend 0.11.0) lib/logflare_logger/http_backend.ex:172: LogflareLogger.HttpBackend.log_level_matches?/2
    (logflare_logger_backend 0.11.0) lib/logflare_logger/http_backend.ex:38: LogflareLogger.HttpBackend.handle_event/2
    (stdlib 4.0) gen_event.erl:793: :gen_event.server_update/4
    (stdlib 4.0) gen_event.erl:775: :gen_event.server_notify/4
    (stdlib 4.0) gen_event.erl:777: :gen_event.server_notify/4
    (stdlib 4.0) gen_event.erl:517: :gen_event.handle_msg/6
    (stdlib 4.0) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:info, #PID<0.1527.0>, {Logger, "Elixir.LogflareLogger.HttpBackend v0.11.0 started.", {{2022, 10, 21}, {10, 47, 43, 707}}, [erl_level: :info, application: :logflare_logger_backend, domain: [:elixir], file: "lib/logflare_logger/http_backend.ex", function: "handle_info/2", gl: #PID<0.1527.0>, line: 48, mfa: {LogflareLogger.HttpBackend, :handle_info, 2}, module: LogflareLogger.HttpBackend, pid: #PID<0.1530.0>, time: 1666316863707591]}}
[error] GenServer #PID<0.1534.0> terminating
** (stop) {:EXIT, {:badarg, [{:logger, :compare_levels, [:info, "debug"], [file: 'logger.erl', line: 621]}, {LogflareLogger.HttpBackend, :log_level_matches?, 2, [file: 'lib/logflare_logger/http_backend.ex', line: 172]}, {LogflareLogger.HttpBackend, :handle_event, 2, [file: 'lib/logflare_logger/http_backend.ex', line: 38]}, {:gen_event, :server_update, 4, [file: 'gen_event.erl', line: 793]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 775]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 777]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 517]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}}
Last message: {:gen_event_EXIT, LogflareLogger.HttpBackend, {:EXIT, {:badarg, [{:logger, :compare_levels, [:info, "debug"], [file: 'logger.erl', line: 621]}, {LogflareLogger.HttpBackend, :log_level_matches?, 2, [file: 'lib/logflare_logger/http_backend.ex', line: 172]}, {LogflareLogger.HttpBackend, :handle_event, 2, [file: 'lib/logflare_logger/http_backend.ex', line: 38]}, {:gen_event, :server_update, 4, [file: 'gen_event.erl', line: 793]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 775]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 777]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 517]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}}}
 ```
