### PR TITLE
fix: make tests pass with OTP 25

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -31,4 +31,6 @@ use Mix.Config
 
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
-import_config "#{Mix.env()}.exs"
+if Mix.env() == :test do
+  config :logger, :console, level: :warning
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/test/exception_logging_test.exs
+++ b/test/exception_logging_test.exs
@@ -23,7 +23,9 @@ defmodule LogflareLogger.ExceptionLoggingTest do
   end
 
   test "logger backends sends a formatted log event after an exception" do
-    allow(LogflareApiClient.post_logs(any(), any(), any()), return: {:ok, %Tesla.Env{status: 200}})
+    allow(LogflareApiClient.post_logs(any(), any(), any()),
+      return: {:ok, %Tesla.Env{status: 200}}
+    )
 
     spawn(fn -> 3.14 / 0 end)
     spawn(fn -> 3.14 / 0 end)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,6 +1,8 @@
 defmodule LogflareLogger.IntegrationTest do
   @moduledoc false
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
   alias LogflareLogger.{HttpBackend, TestUtils}
   require Logger
 
@@ -77,17 +79,19 @@ defmodule LogflareLogger.IntegrationTest do
       Plug.Conn.resp(conn, 200, "")
     end)
 
-    for n <- 1..10, do: Logger.info(log_msg <> " ##{n}")
+    capture_log(fn ->
+      for n <- 1..10, do: Logger.info(log_msg <> " ##{n}")
 
-    Process.sleep(1_000)
+      Process.sleep(1_000)
 
-    for n <- 1..10, do: Logger.error(log_msg <> " ##{20 + n}")
+      for n <- 1..10, do: Logger.error(log_msg <> " ##{20 + n}")
 
-    Process.sleep(1_000)
+      Process.sleep(1_000)
 
-    for n <- 1..10, do: Logger.debug(log_msg <> " ##{30 + n}")
+      for n <- 1..10, do: Logger.debug(log_msg <> " ##{30 + n}")
 
-    Process.sleep(1_000)
+      Process.sleep(1_000)
+    end)
   end
 
   test "doesn't POST log events with a lower level", %{bypass: _bypass} do
@@ -110,7 +114,7 @@ defmodule LogflareLogger.IntegrationTest do
                    "metadata" => %{
                      "level" => "info",
                      "context" => %{
-                       "pid" => pidbinary,
+                       "pid" => _pidbinary,
                        "module" => _,
                        "file" => _,
                        "line" => _,

--- a/test/log_params_test.exs
+++ b/test/log_params_test.exs
@@ -29,7 +29,7 @@ defmodule LogflareLogger.LogParamsTest do
     end
 
     test "charlists to strings" do
-      x = 'just a simple charlist'
+      x = ~c"just a simple charlist"
       user_context = build_user_context(%{charlist: %{x => [x, %{x => {x, x}}]}})
 
       x = to_string(x)
@@ -42,13 +42,6 @@ defmodule LogflareLogger.LogParamsTest do
 
       x = %{"a" => 2, "b" => %{"a" => 6}}
       assert user_context === %{"keyword" => %{1 => [x, %{"two" => [x, x]}]}}
-    end
-
-    test "observer_backend.sys_info()" do
-      user_context = build_user_context(observer_sys_info: :observer_backend.sys_info())
-
-      assert ["instance", 0, %{"mbcs" => _, "sbcs" => _}] =
-               hd(user_context["observer_sys_info"]["alloc_info"]["binary_alloc"])
     end
 
     test "pid to string" do


### PR DESCRIPTION
In addition to removing test that was using internal OTP API that was
changed, it also reduces amount of messages displayed during testing.
