### PR TITLE
fix: single in-flight flush call

### DIFF
--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -27,12 +27,8 @@ defmodule LogflareLogger.BatchCache do
         |> Enum.each(&Repo.delete/1)
       end
 
-      events = pending_events |> Enum.map(& &1.body)
-      events_count = Enum.count(events)
-
-      if events_count >= config.batch_max_size do
-        flush(config)
-      end
+      if pending_events_count >= config.batch_max_size,
+        do: flush(config)
 
       {:ok, :insert_successful}
     else
@@ -45,7 +41,7 @@ defmodule LogflareLogger.BatchCache do
 
     pending_events = pending_events_not_in_flight()
 
-    if not Enum.empty?(pending_events) do
+    if !Enum.empty?(pending_events) && events_in_flight() == [] do
       ples =
         pending_events
         |> Enum.map(fn ple ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogflareLogger.MixProject do
   def project do
     [
       app: :logflare_logger_backend,
-      version: "0.11.4",
+      version: "0.11.5",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogflareLogger.MixProject do
   def project do
     [
       app: :logflare_logger_backend,
-      version: "0.11.5",
+      version: "0.11.5-rc.0",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- fixes a bug where timeouts POSTing to Logflare could cause lots of tasks spun up if lots of log events are being logged (thousands per second)
- will spin off a task to POST log events (`flush`) only when there are no log events in-flight 