### PR TITLE
perf: batch cache (and some misc) optimizations

### DIFF
--- a/lib/in_flight_log_event.ex
+++ b/lib/in_flight_log_event.ex
@@ -1,0 +1,13 @@
+defmodule LogflareLogger.InFlightLoggerEvent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "in_flight_logger_events" do
+    field :body, :map
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:body])
+  end
+end

--- a/lib/logflare_logger/application.ex
+++ b/lib/logflare_logger/application.ex
@@ -5,7 +5,8 @@ defmodule LogflareLogger.Application do
 
   def start(_type, _args) do
     children = [
-      LogflareLogger.Repo
+      LogflareLogger.Repo,
+      LogflareLogger.BatchServer
     ]
 
     opts = [strategy: :one_for_one, name: LogflareLogger.Supervisor]

--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -33,8 +33,17 @@ defmodule LogflareLogger.BatchCache do
         |> Enum.each(&Repo.delete/1)
       end
 
-      if pending_count >= config.batch_max_size do
-        BatchServer.flush(config)
+      sync_threshold = min(config.batch_max_size * 4, div(@batch_limit, 2))
+
+      cond do
+        pending_count >= sync_threshold ->
+          BatchServer.flush(config)
+
+        pending_count >= config.batch_max_size ->
+          BatchServer.flush_async(config)
+
+        true ->
+          :ok
       end
 
       {:ok, :insert_successful}

--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -2,12 +2,16 @@ defmodule LogflareLogger.BatchCache do
   @moduledoc """
   Caches the batch, dispatches API post request if the batch is larger than configured max batch size or flush is called.
 
-  Doesn't error or drop the message if the API is unresponsive, holds them
+  Doesn't error or drop the message if the API is unresponsive, holds them.
+
+  Uses two separate Etso tables:
+  - PendingLoggerEvent: events waiting to be sent
+  - InFlightLoggerEvent: events currently being sent to the API
   """
 
   alias LogflareLogger.Repo
   alias LogflareLogger.PendingLoggerEvent
-  import Ecto.Query
+  alias LogflareLogger.InFlightLoggerEvent
 
   require Logger
 
@@ -20,19 +24,15 @@ defmodule LogflareLogger.BatchCache do
       |> PendingLoggerEvent.changeset(%{body: event})
       |> Repo.insert!()
 
-      pending_events = pending_events_not_in_flight()
-      pending_events_count = Enum.count(pending_events)
+      pending_count = ets_size(PendingLoggerEvent)
 
-      if pending_events_count > @batch_limit do
-        pending_events
-        |> Enum.take(pending_events_count - @batch_limit)
+      if pending_count > @batch_limit do
+        pending_events_asc()
+        |> Enum.take(pending_count - @batch_limit)
         |> Enum.each(&Repo.delete/1)
       end
 
-      events = pending_events |> Enum.map(& &1.body)
-      events_count = Enum.count(events)
-
-      if events_count >= config.batch_max_size do
+      if pending_count >= config.batch_max_size do
         flush(config)
       end
 
@@ -43,24 +43,22 @@ defmodule LogflareLogger.BatchCache do
   end
 
   def flush(config) do
-    api_request_started_at = System.monotonic_time()
-
-    pending_events = pending_events_not_in_flight()
+    pending_events = pending_events_asc()
 
     if not Enum.empty?(pending_events) do
-      ples =
-        pending_events
-        |> Enum.map(fn ple ->
-          {:ok, ple} =
-            ple
-            |> PendingLoggerEvent.changeset(%{api_request_started_at: api_request_started_at})
-            |> Repo.update()
+      in_flight =
+        Enum.map(pending_events, fn ple ->
+          {:ok, ife} =
+            %InFlightLoggerEvent{}
+            |> InFlightLoggerEvent.changeset(%{body: ple.body})
+            |> Repo.insert()
 
-          ple
+          Repo.delete!(ple)
+          ife
         end)
 
       Task.start(fn ->
-        ples
+        in_flight
         |> post_logs(config)
         |> case do
           {:ok, %Tesla.Env{status: status, body: body}} ->
@@ -70,14 +68,14 @@ defmodule LogflareLogger.BatchCache do
               )
             end
 
-            for ple <- ples do
-              Repo.delete(ple)
+            for ife <- in_flight do
+              Repo.delete(ife)
             end
 
           {:error, reason} ->
             Logger.warning("Logflare API error: #{inspect(reason)}")
 
-            reset_events_in_flight(ples)
+            reset_events_in_flight(in_flight)
 
             :noop
         end
@@ -88,7 +86,8 @@ defmodule LogflareLogger.BatchCache do
   end
 
   def clear do
-    Repo.all(PendingLoggerEvent) |> Enum.map(&Repo.delete(&1))
+    Repo.all(PendingLoggerEvent) |> Enum.each(&Repo.delete/1)
+    Repo.all(InFlightLoggerEvent) |> Enum.each(&Repo.delete/1)
   end
 
   def post_logs(events, %{api_client: api_client, source_id: source_id}) do
@@ -96,30 +95,35 @@ defmodule LogflareLogger.BatchCache do
     LogflareApiClient.post_logs(api_client, events, source_id)
   end
 
-  def sort_by_created_asc(pending_events) do
-    # etso id is System.monotonic_time
-    Enum.sort_by(pending_events, & &1.id, &<=/2)
-  end
-
   def events_in_flight() do
-    from(PendingLoggerEvent)
-    |> where([le], le.api_request_started_at != 0)
-    |> Repo.all()
-    |> sort_by_created_asc()
-  end
-
-  def pending_events_not_in_flight() do
-    from(PendingLoggerEvent)
-    |> where([le], le.api_request_started_at == 0)
-    |> Repo.all()
+    Repo.all(InFlightLoggerEvent)
     |> sort_by_created_asc()
   end
 
   def reset_events_in_flight(events) do
     for e <- events do
-      e
-      |> PendingLoggerEvent.changeset(%{api_request_started_at: 0})
-      |> Repo.update()
+      {:ok, ple} =
+        %PendingLoggerEvent{}
+        |> PendingLoggerEvent.changeset(%{body: e.body})
+        |> Repo.insert()
+
+      Repo.delete(e)
+      ple
     end
+  end
+
+  defp pending_events_asc do
+    Repo.all(PendingLoggerEvent)
+    |> sort_by_created_asc()
+  end
+
+  defp sort_by_created_asc(events) do
+    # etso id is System.monotonic_time
+    Enum.sort_by(events, & &1.id, &<=/2)
+  end
+
+  defp ets_size(schema) do
+    {:ok, table} = Etso.Adapter.TableRegistry.get_table(Repo, schema)
+    :ets.info(table, :size)
   end
 end

--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -7,13 +7,14 @@ defmodule LogflareLogger.BatchCache do
   Uses two separate Etso tables:
   - PendingLoggerEvent: events waiting to be sent
   - InFlightLoggerEvent: events currently being sent to the API
+
+  Write path (`put/2`) goes directly to ETS for performance.
+  Flush/clear/reset are serialized through BatchServer.
   """
 
   alias LogflareLogger.Repo
   alias LogflareLogger.PendingLoggerEvent
-  alias LogflareLogger.InFlightLoggerEvent
-
-  require Logger
+  alias LogflareLogger.BatchServer
 
   # batch limit prevents runaway memory usage if API is unresponsive
   @batch_limit 10_000
@@ -33,7 +34,7 @@ defmodule LogflareLogger.BatchCache do
       end
 
       if pending_count >= config.batch_max_size do
-        flush(config)
+        BatchServer.flush(config)
       end
 
       {:ok, :insert_successful}
@@ -42,84 +43,17 @@ defmodule LogflareLogger.BatchCache do
     end
   end
 
-  def flush(config) do
-    pending_events = pending_events_asc()
+  def flush(config), do: BatchServer.flush(config)
 
-    if not Enum.empty?(pending_events) do
-      in_flight =
-        Enum.map(pending_events, fn ple ->
-          {:ok, ife} =
-            %InFlightLoggerEvent{}
-            |> InFlightLoggerEvent.changeset(%{body: ple.body})
-            |> Repo.insert()
+  def clear, do: BatchServer.clear()
 
-          Repo.delete!(ple)
-          ife
-        end)
+  def events_in_flight, do: BatchServer.events_in_flight()
 
-      Task.start(fn ->
-        in_flight
-        |> post_logs(config)
-        |> case do
-          {:ok, %Tesla.Env{status: status, body: body}} ->
-            unless status in 200..299 do
-              Logger.warning(
-                "Logflare API warning: HTTP response status is #{status}. Response body is: #{inspect(body)}"
-              )
-            end
-
-            for ife <- in_flight do
-              Repo.delete(ife)
-            end
-
-          {:error, reason} ->
-            Logger.warning("Logflare API error: #{inspect(reason)}")
-
-            reset_events_in_flight(in_flight)
-
-            :noop
-        end
-      end)
-    else
-      :noop
-    end
-  end
-
-  def clear do
-    Repo.all(PendingLoggerEvent) |> Enum.each(&Repo.delete/1)
-    Repo.all(InFlightLoggerEvent) |> Enum.each(&Repo.delete/1)
-  end
-
-  def post_logs(events, %{api_client: api_client, source_id: source_id}) do
-    events = Enum.map(events, & &1.body)
-    LogflareApiClient.post_logs(api_client, events, source_id)
-  end
-
-  def events_in_flight() do
-    Repo.all(InFlightLoggerEvent)
-    |> sort_by_created_asc()
-  end
-
-  def reset_events_in_flight(events) do
-    for e <- events do
-      {:ok, ple} =
-        %PendingLoggerEvent{}
-        |> PendingLoggerEvent.changeset(%{body: e.body})
-        |> Repo.insert()
-
-      Repo.delete(e)
-      ple
-    end
-  end
+  def reset_events_in_flight(events), do: BatchServer.reset_events_in_flight(events)
 
   defp pending_events_asc do
     Repo.all(PendingLoggerEvent)
-    |> sort_by_created_asc()
-  end
-
-  defp sort_by_created_asc(events) do
-    # etso id is System.monotonic_time
-    Enum.sort_by(events, & &1.id, &<=/2)
+    |> Enum.sort_by(& &1.id, &<=/2)
   end
 
   defp ets_size(schema) do

--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -47,10 +47,6 @@ defmodule LogflareLogger.BatchCache do
 
   def clear, do: BatchServer.clear()
 
-  def reset_events_in_flight, do: BatchServer.reset_events_in_flight()
-
-  def reset_events_in_flight(events), do: BatchServer.reset_events_in_flight(events)
-
   defp pending_events_asc do
     Repo.all(PendingLoggerEvent)
     |> Enum.sort_by(& &1.id, &<=/2)

--- a/lib/logflare_logger/batch_cache.ex
+++ b/lib/logflare_logger/batch_cache.ex
@@ -47,7 +47,7 @@ defmodule LogflareLogger.BatchCache do
 
   def clear, do: BatchServer.clear()
 
-  def events_in_flight, do: BatchServer.events_in_flight()
+  def reset_events_in_flight, do: BatchServer.reset_events_in_flight()
 
   def reset_events_in_flight(events), do: BatchServer.reset_events_in_flight(events)
 

--- a/lib/logflare_logger/batch_server.ex
+++ b/lib/logflare_logger/batch_server.ex
@@ -1,8 +1,6 @@
 defmodule LogflareLogger.BatchServer do
   @moduledoc """
   Serializes flush, clear, and reset operations on the batch tables.
-
-  `put/2` bypasses this server for performance — it writes directly to ETS.
   """
 
   use GenServer

--- a/lib/logflare_logger/batch_server.ex
+++ b/lib/logflare_logger/batch_server.ex
@@ -1,0 +1,117 @@
+defmodule LogflareLogger.BatchServer do
+  @moduledoc """
+  Serializes flush, clear, and reset operations on the batch tables.
+
+  `put/2` bypasses this server for performance — it writes directly to ETS.
+  """
+
+  use GenServer
+
+  alias LogflareLogger.Repo
+  alias LogflareLogger.PendingLoggerEvent
+  alias LogflareLogger.InFlightLoggerEvent
+  import Ecto.Query
+
+  require Logger
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def flush(config) do
+    GenServer.cast(__MODULE__, {:flush, config})
+  end
+
+  def clear do
+    GenServer.call(__MODULE__, :clear)
+  end
+
+  def events_in_flight do
+    GenServer.call(__MODULE__, :events_in_flight)
+  end
+
+  def reset_events_in_flight(events) do
+    GenServer.call(__MODULE__, {:reset_events_in_flight, events})
+  end
+
+  # Server callbacks
+
+  @impl true
+  def init(_opts) do
+    # Ensure ETS tables exist so delete_all doesn't crash on empty tables
+    Etso.Adapter.TableRegistry.get_table(Repo, PendingLoggerEvent)
+    Etso.Adapter.TableRegistry.get_table(Repo, InFlightLoggerEvent)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_cast({:flush, config}, state) do
+    do_flush(config)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:clear, _from, state) do
+    Repo.delete_all(from(PendingLoggerEvent))
+    Repo.delete_all(from(InFlightLoggerEvent))
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:events_in_flight, _from, state) do
+    events = Repo.all(InFlightLoggerEvent)
+    {:reply, events, state}
+  end
+
+  def handle_call({:reset_events_in_flight, events}, _from, state) do
+    bodies = Enum.map(events, &%{body: &1.body})
+    Repo.insert_all(PendingLoggerEvent, bodies)
+
+    for e <- events, do: Repo.delete(e)
+
+    {:reply, length(events), state}
+  end
+
+  defp do_flush(config) do
+    pending_events = Repo.all(PendingLoggerEvent)
+
+    if not Enum.empty?(pending_events) do
+      in_flight_maps =
+        Enum.map(pending_events, fn ple ->
+          %{id: :erlang.unique_integer(), body: ple.body}
+        end)
+
+      Repo.insert_all(InFlightLoggerEvent, in_flight_maps)
+
+      in_flight_entries = Enum.map(in_flight_maps, &struct(InFlightLoggerEvent, &1))
+
+      for ple <- pending_events, do: Repo.delete(ple)
+
+      Task.start(fn ->
+        in_flight_entries
+        |> post_logs(config)
+        |> case do
+          {:ok, %Tesla.Env{status: status, body: body}} ->
+            unless status in 200..299 do
+              Logger.warning(
+                "Logflare API warning: HTTP response status is #{status}. Response body is: #{inspect(body)}"
+              )
+            end
+
+            for ife <- in_flight_entries, do: Repo.delete(ife)
+
+          {:error, reason} ->
+            Logger.warning("Logflare API error: #{inspect(reason)}")
+
+            reset_events_in_flight(in_flight_entries)
+
+            :noop
+        end
+      end)
+    end
+  end
+
+  defp post_logs(events, %{api_client: api_client, source_id: source_id}) do
+    bodies = Enum.map(events, & &1.body)
+    LogflareApiClient.post_logs(api_client, bodies, source_id)
+  end
+end

--- a/lib/logflare_logger/batch_server.ex
+++ b/lib/logflare_logger/batch_server.ex
@@ -26,8 +26,8 @@ defmodule LogflareLogger.BatchServer do
     GenServer.call(__MODULE__, :clear)
   end
 
-  def events_in_flight do
-    GenServer.call(__MODULE__, :events_in_flight)
+  def reset_events_in_flight do
+    GenServer.call(__MODULE__, :reset_events_in_flight)
   end
 
   def reset_events_in_flight(events) do
@@ -57,9 +57,17 @@ defmodule LogflareLogger.BatchServer do
     {:reply, :ok, state}
   end
 
-  def handle_call(:events_in_flight, _from, state) do
+  def handle_call(:reset_events_in_flight, _from, state) do
     events = Repo.all(InFlightLoggerEvent)
-    {:reply, events, state}
+
+    if events != [] do
+      bodies = Enum.map(events, &%{body: &1.body})
+      Repo.insert_all(PendingLoggerEvent, bodies)
+
+      for e <- events, do: Repo.delete(e)
+    end
+
+    {:reply, length(events), state}
   end
 
   def handle_call({:reset_events_in_flight, events}, _from, state) do

--- a/lib/logflare_logger/batch_server.ex
+++ b/lib/logflare_logger/batch_server.ex
@@ -26,14 +26,6 @@ defmodule LogflareLogger.BatchServer do
     GenServer.call(__MODULE__, :clear)
   end
 
-  def reset_events_in_flight do
-    GenServer.call(__MODULE__, :reset_events_in_flight)
-  end
-
-  def reset_events_in_flight(events) do
-    GenServer.call(__MODULE__, {:reset_events_in_flight, events})
-  end
-
   # Server callbacks
 
   @impl true
@@ -41,6 +33,7 @@ defmodule LogflareLogger.BatchServer do
     # Ensure ETS tables exist so delete_all doesn't crash on empty tables
     Etso.Adapter.TableRegistry.get_table(Repo, PendingLoggerEvent)
     Etso.Adapter.TableRegistry.get_table(Repo, InFlightLoggerEvent)
+    Process.send_after(self(), :reset_events_in_flight, 0)
     {:ok, %{}}
   end
 
@@ -51,13 +44,7 @@ defmodule LogflareLogger.BatchServer do
   end
 
   @impl true
-  def handle_call(:clear, _from, state) do
-    Repo.delete_all(from(PendingLoggerEvent))
-    Repo.delete_all(from(InFlightLoggerEvent))
-    {:reply, :ok, state}
-  end
-
-  def handle_call(:reset_events_in_flight, _from, state) do
+  def handle_info(:reset_events_in_flight, state) do
     events = Repo.all(InFlightLoggerEvent)
 
     if events != [] do
@@ -65,18 +52,20 @@ defmodule LogflareLogger.BatchServer do
       Repo.insert_all(PendingLoggerEvent, bodies)
 
       for e <- events, do: Repo.delete(e)
+
+      Logger.warning(
+        "LogflareLogger resetting #{length(events)} log events in flight. If this continues please submit an issue."
+      )
     end
 
-    {:reply, length(events), state}
+    {:noreply, state}
   end
 
-  def handle_call({:reset_events_in_flight, events}, _from, state) do
-    bodies = Enum.map(events, &%{body: &1.body})
-    Repo.insert_all(PendingLoggerEvent, bodies)
-
-    for e <- events, do: Repo.delete(e)
-
-    {:reply, length(events), state}
+  @impl true
+  def handle_call(:clear, _from, state) do
+    Repo.delete_all(from(PendingLoggerEvent))
+    Repo.delete_all(from(InFlightLoggerEvent))
+    {:reply, :ok, state}
   end
 
   defp do_flush(config) do
@@ -110,7 +99,10 @@ defmodule LogflareLogger.BatchServer do
           {:error, reason} ->
             Logger.warning("Logflare API error: #{inspect(reason)}")
 
-            reset_events_in_flight(in_flight_entries)
+            bodies = Enum.map(in_flight_entries, &%{body: &1.body})
+            Repo.insert_all(PendingLoggerEvent, bodies)
+
+            for e <- in_flight_entries, do: Repo.delete(e)
 
             :noop
         end

--- a/lib/logflare_logger/batch_server.ex
+++ b/lib/logflare_logger/batch_server.ex
@@ -19,6 +19,10 @@ defmodule LogflareLogger.BatchServer do
   end
 
   def flush(config) do
+    GenServer.call(__MODULE__, {:flush, config})
+  end
+
+  def flush_async(config) do
     GenServer.cast(__MODULE__, {:flush, config})
   end
 
@@ -35,6 +39,19 @@ defmodule LogflareLogger.BatchServer do
     Etso.Adapter.TableRegistry.get_table(Repo, InFlightLoggerEvent)
     Process.send_after(self(), :reset_events_in_flight, 0)
     {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:flush, config}, _from, state) do
+    do_flush(config)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:clear, _from, state) do
+    Repo.delete_all(from(PendingLoggerEvent))
+    Repo.delete_all(from(InFlightLoggerEvent))
+    {:reply, :ok, state}
   end
 
   @impl true
@@ -59,13 +76,6 @@ defmodule LogflareLogger.BatchServer do
     end
 
     {:noreply, state}
-  end
-
-  @impl true
-  def handle_call(:clear, _from, state) do
-    Repo.delete_all(from(PendingLoggerEvent))
-    Repo.delete_all(from(InFlightLoggerEvent))
-    {:reply, :ok, state}
   end
 
   defp do_flush(config) do

--- a/lib/logflare_logger/http_backend.ex
+++ b/lib/logflare_logger/http_backend.ex
@@ -53,7 +53,7 @@ defmodule LogflareLogger.HttpBackend do
   def handle_info(:in_flight_check, config) do
     # If we somehow have events in flight stuck in our Repo, they get reset here to get flushed to Logflare.
     if GenServer.whereis(LogflareLogger.Repo) do
-      count = BatchCache.events_in_flight() |> BatchCache.reset_events_in_flight() |> Enum.count()
+      count = BatchCache.events_in_flight() |> BatchCache.reset_events_in_flight()
 
       if count > 0 do
         msg =

--- a/lib/logflare_logger/http_backend.ex
+++ b/lib/logflare_logger/http_backend.ex
@@ -18,7 +18,6 @@ defmodule LogflareLogger.HttpBackend do
 
   @spec init(__MODULE__, keyword) :: {:ok, Config.t()}
   def init(__MODULE__, options \\ []) when is_list(options) do
-    schedule_in_flight_check()
     msg = "#{__MODULE__} v#{Application.spec(@app, :vsn)} started."
     log_after(:info, msg)
 
@@ -46,22 +45,6 @@ defmodule LogflareLogger.HttpBackend do
 
   def handle_info({:log_after, level, message}, config) do
     Logger.log(level, message)
-
-    {:ok, config}
-  end
-
-  def handle_info(:in_flight_check, config) do
-    # If we somehow have events in flight stuck in our Repo, they get reset here to get flushed to Logflare.
-    if GenServer.whereis(LogflareLogger.Repo) do
-      count = BatchCache.reset_events_in_flight()
-
-      if count > 0 do
-        msg =
-          "#{__MODULE__} v#{Application.spec(@app, :vsn)} resetting #{count} log events in flight. If this continues please submit an issue."
-
-        log_after(:warning, msg)
-      end
-    end
 
     {:ok, config}
   end
@@ -154,10 +137,6 @@ defmodule LogflareLogger.HttpBackend do
   defp schedule_flush(%Config{} = config) do
     Process.send_after(self(), :flush, config.flush_interval)
     {:ok, config}
-  end
-
-  defp schedule_in_flight_check() do
-    Process.send_after(self(), :in_flight_check, 0)
   end
 
   defp log_after(level, message, delay \\ 5_000) do

--- a/lib/logflare_logger/http_backend.ex
+++ b/lib/logflare_logger/http_backend.ex
@@ -53,7 +53,7 @@ defmodule LogflareLogger.HttpBackend do
   def handle_info(:in_flight_check, config) do
     # If we somehow have events in flight stuck in our Repo, they get reset here to get flushed to Logflare.
     if GenServer.whereis(LogflareLogger.Repo) do
-      count = BatchCache.events_in_flight() |> BatchCache.reset_events_in_flight()
+      count = BatchCache.reset_events_in_flight()
 
       if count > 0 do
         msg =

--- a/lib/logflare_logger/log_params.ex
+++ b/lib/logflare_logger/log_params.ex
@@ -60,15 +60,28 @@ defmodule LogflareLogger.LogParams do
     encode_timestamp({date, {hour, minute, second, 0}})
   end
 
-  def encode_timestamp({date, {hour, minute, second, {_micro, 6} = fractions_with_precision}}) do
-    {date, {hour, minute, second}}
-    |> NaiveDateTime.from_erl!(fractions_with_precision)
-    |> NaiveDateTime.to_iso8601(:extended)
-    |> Kernel.<>("Z")
+  def encode_timestamp({{year, month, day}, {hour, minute, second, {micro, 6}}}) do
+    [
+      Integer.to_string(year),
+      ?-,
+      pad2(month),
+      ?-,
+      pad2(day),
+      ?T,
+      pad2(hour),
+      ?:,
+      pad2(minute),
+      ?:,
+      pad2(second),
+      ?.,
+      pad6(micro),
+      ?Z
+    ]
+    |> IO.iodata_to_binary()
   end
 
   def encode_timestamp({date, {hour, minute, second, milli}}) when is_integer(milli) do
-    erldt =
+    {utc_date, {uh, um, us}} =
       {date, {hour, minute, second}}
       |> :calendar.local_time_to_universal_time_dst()
       |> case do
@@ -77,11 +90,18 @@ defmodule LogflareLogger.LogParams do
         [_, dt_utc] -> dt_utc
       end
 
-    erldt
-    |> NaiveDateTime.from_erl!({milli * 1000, 6})
-    |> NaiveDateTime.to_iso8601(:extended)
-    |> Kernel.<>("Z")
+    encode_timestamp({utc_date, {uh, um, us, {milli * 1000, 6}}})
   end
+
+  defp pad2(int) when int < 10, do: [?0, Integer.to_string(int)]
+  defp pad2(int), do: Integer.to_string(int)
+
+  defp pad6(int) when int < 10, do: [~c"00000", Integer.to_string(int)]
+  defp pad6(int) when int < 100, do: [~c"0000", Integer.to_string(int)]
+  defp pad6(int) when int < 1_000, do: [~c"000", Integer.to_string(int)]
+  defp pad6(int) when int < 10_000, do: [~c"00", Integer.to_string(int)]
+  defp pad6(int) when int < 100_000, do: [?0, Integer.to_string(int)]
+  defp pad6(int), do: Integer.to_string(int)
 
   def encode_metadata(meta) when is_list(meta) when is_map(meta) do
     meta

--- a/lib/logflare_logger/log_params.ex
+++ b/lib/logflare_logger/log_params.ex
@@ -150,6 +150,8 @@ defmodule LogflareLogger.LogParams do
     end
   end
 
+  def traverse_convert([]), do: []
+
   def traverse_convert(xs) when is_list(xs) do
     cond do
       Keyword.keyword?(xs) ->

--- a/lib/pending_log_event.ex
+++ b/lib/pending_log_event.ex
@@ -13,9 +13,7 @@ defmodule LogflareLogger.PendingLoggerEvent do
   end
 
   defp fix_body(change) do
-    change
-    |> Enum.map(fn {k, v} -> {k, check_deep_struct(v)} end)
-    |> Map.new()
+    Map.new(change, fn {k, v} -> {k, check_deep_struct(v)} end)
   end
 
   defp check_deep_struct(%Date{} = value), do: Date.to_iso8601(value)
@@ -25,9 +23,7 @@ defmodule LogflareLogger.PendingLoggerEvent do
   defp check_deep_struct(value) when is_struct(value), do: safe_encode(value, :transform)
 
   defp check_deep_struct(value) when is_map(value) do
-    value
-    |> Enum.map(fn {k, v} -> {k, check_deep_struct(v)} end)
-    |> Map.new()
+    Map.new(value, fn {k, v} -> {k, check_deep_struct(v)} end)
   end
 
   defp check_deep_struct([]), do: []

--- a/lib/pending_log_event.ex
+++ b/lib/pending_log_event.ex
@@ -57,7 +57,7 @@ defmodule LogflareLogger.PendingLoggerEvent do
   defp safe_encode(v, _) when is_binary(v), do: v
 
   defp safe_encode(v, :preserve) do
-    case Jason.encode(v) do
+    case Jason.encode_to_iodata(v) do
       {:ok, _} -> v
       {:error, _} -> inspect(v)
     end

--- a/lib/pending_log_event.ex
+++ b/lib/pending_log_event.ex
@@ -4,12 +4,11 @@ defmodule LogflareLogger.PendingLoggerEvent do
 
   schema "logger_events" do
     field :body, :map
-    field :api_request_started_at, :integer, default: 0
   end
 
   def changeset(struct, params) do
     struct
-    |> cast(params, [:body, :api_request_started_at])
+    |> cast(params, [:body])
     |> update_change(:body, &fix_body/1)
   end
 


### PR DESCRIPTION
Currently, `BatchCache.put/2` always reads all pending messages and sorts them to detect overflow and discard the oldest messages. Since pending and in-flight messages are in the same table, it must filter to select only the pending ones. 

This PR avoids the `ets:select` on every iteration by splitting pending and in-flight into two different tables. This allows us to use the size of the pending mesages ETS instead of selecting messages every time. I've considered a few different approaches (like using counters) but I felt like this was more straightforward.

When the batch is overflowing, it __still__ runs the select and sort. So in case of a Logflare outage, #115 still sort of applies. But this should improve the performance when logflare is operational. In my tests, with a batch size of 100, the performance more than doubled, and memory was also decreased. I have added some stats in the commits. Notice that after I introduced the BatchServer, memory measurements must be done differently. 

Some notes: 
- I also implemented a BatchServer. It avoids concurrent flushes (which were a problem on LogflareLogger), and facilitated thinking about concurrency. It also ensures that LogflareLogger also has periodic flushes (which it didn't, only the backend had).
- Previously, flush was always sync. I made it async by default but sync if the pending list is at least a few batches big. Making it async by default allows it to handle more messages, but having a fallback to sync ensures it doesn't lose the backpressure that existed at this level.
- I also have a few commits for some small random optimizations. They don't necessarily make a significative difference, but they make us have less reductions/allocations and were trivial enough.

